### PR TITLE
Fix example usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ A 6502 disassembler written in TypeScript.
 ### Usage
 
     const d = require("6502-disasm");
-    const disasm = new d.Disassembler([0x61, 0xFA]);
-    disasm.decodeNext(); // Outputs "ADC ($00,X)"
+    const disasm = new d.Disassembler(new Uint8Array([0x61, 0xFA]));
+    disasm.decode(); // Outputs [ 'ADC ($FA,X)' ]


### PR DESCRIPTION
The current example fails with undefined method errors; this pull request fixes it to pass a typed array and to call the decode function, returning valid disassembly.